### PR TITLE
Support CloudDeck (and probably some other Linux distributions) compa…

### DIFF
--- a/fallout.sh
+++ b/fallout.sh
@@ -665,6 +665,22 @@ if [ "$LAST_STEP" -lt 7 ]; then
 			exit
 		fi
 
+  		# Remove existing symlink if it exists
+		if [ -L "$WINEPREFIX/dosdevices/i:" ]; then
+			rm "$WINEPREFIX/dosdevices/i:"
+		fi
+  
+   		# Create the new symlink
+  		ln -s "$FALLOUT_LONDON_DIR" "$WINEPREFIX/dosdevices/i:"
+
+		# Verify the symlink
+		if [ -L "$WINEPREFIX/dosdevices/i:" ]; then
+			echo "Drive I: successfully created pointing to $FALLOUT_LONDON_DIR"
+		else
+			echo "Failed to create Drive I:"
+			exit
+		fi
+
 		# Run the game using Proton with the specified Wine prefix and compatibility data path
 		killall wineserver
 


### PR DESCRIPTION
…tibility

Added an I: drive linked to $FALLOUT_LONDON_DIR for better compatibility with other distributions of Linux.

For example, on the CloudDeck system (a kind of "Steam Deck in the cloud" based on Nobara Linux), without this change, the "Fallout London Installer" couldn't find the default location Z:/home/userGames/Heroic/Fallout\ London/ because /home/user doesn't appear in the Z: drive with those versions of Linux/Steam/Proton environments.

This change has been tested on:

CloudDeck: Tested without sudo, and therefore without changing the mutability status of the manifest file to automatically disable updates.

Ubuntu 24.10: No sound for the moment, but this issue is not related to this change.