### PR TITLE
Add instruction to quit steam before running script - README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Note: Right now, this script applies [the optimized .ini](https://github.com/kru
 ---
 
 ## Installation
+First, close Steam by clicking on its icon in the taskbar, and click `Exit Steam`.
 
 To run the script, run the command below.
 


### PR DESCRIPTION
Resolves #8 

SteamCMD docs say users may have only one active login:

(at section SteamCMD Login)
https://developer.valvesoftware.com/wiki/SteamCMD

A user can only be logged in once at any time (counting both grapical client as well as SteamCMD logins).

SteamDB says you need to auth when downloading old versions of packages: https://steamdb.info/blog/manifest-request-codes/